### PR TITLE
fix gallery overlapping canvas on zoom

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -26,10 +26,13 @@ a {
     width: 100%;
     padding-top: 10%;
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: center;
     flex-flow: column;
     position: relative;
+    height: 100vh;
+    min-height: 800px;
+    box-sizing: border-box;
 }
 
 #wrapper .info > div {
@@ -286,9 +289,6 @@ canvas {
 }
 
 #gallery {
-    position: absolute;
-    top: 100vh;
-    width: 100%;
     min-height: 101vh;
     padding-top: 16px;
     background: #111;


### PR DESCRIPTION
add min height to wrapper
remove position absolute from gallery

resolves #25 